### PR TITLE
Allow using versions of Opal beyond 0.8.x (aka 0.9.x)

### DIFF
--- a/jekyll-opal.gemspec
+++ b/jekyll-opal.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "opal", "~> 0.8.0"
+  spec.add_runtime_dependency "opal", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I tested this gem with Opal 0.9.2 and it's working fine, but I had to make this change to the gemspec file first.
